### PR TITLE
Switch to using `StarterPlayer.StarterPlayerScripts` for path

### DIFF
--- a/src/Shared/Settings/ClientPaths.lua
+++ b/src/Shared/Settings/ClientPaths.lua
@@ -8,7 +8,7 @@
 -- Roblox Services --
 ---------------------
 local ReplicatedStorage=game:GetService("ReplicatedStorage")
-local Players=game:GetService("Players")
+local StarterPlayer = game:GetService("StarterPlayer")
 
 return {
 	ModulePaths = {
@@ -19,6 +19,6 @@ return {
 	},
 
 	ControllerPaths = {
-		Players.LocalPlayer.PlayerScripts.DragonEngine.Controllers
+		StarterPlayer.StarterPlayerScripts.DragonEngine.Controllers
 	}
 }


### PR DESCRIPTION
This PR changes the framework's configs to read directly from `StarterPlayerScripts` instead of reading from the player's `PlayerScripts` folder. Closes #63.