### PR TITLE
Remove dependency on player object

### DIFF
--- a/src/Client/Core/DragonEngine.client.lua
+++ b/src/Client/Core/DragonEngine.client.lua
@@ -8,7 +8,7 @@
 -- Roblox Services --
 ---------------------
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local Players = game:GetService("Players")
+local StarterPlayer = game:GetService("StarterPlayer")
 
 --------------
 -- REQUIRES --
@@ -42,7 +42,7 @@ local Service_Endpoints = ReplicatedStorage.DragonEngine.Network.Service_Endpoin
 local Service_ClientEndpoints = ReplicatedStorage.DragonEngine.Network.Service_ClientEndpoints
 local Controller_Events = Instance.new('Folder') --A folder containing the client sided events for controllers.
 	  Controller_Events.Name = "Controller_Events"
-	  Controller_Events.Parent = Players.LocalPlayer.PlayerScripts.DragonEngine
+	  Controller_Events.Parent = StarterPlayer.StarterPlayerScripts.DragonEngine
 
 ------------
 -- Events --


### PR DESCRIPTION
This PR fixes a left over dependency on the player object that was missed during the release of `v0.1.0-rc.5`.