### PR TITLE
Fix dependency refs

### DIFF
--- a/src/Server/Services/EngineDebugService/init.lua
+++ b/src/Server/Services/EngineDebugService/init.lua
@@ -70,7 +70,7 @@ function EngineEngineDebugService:Init()
 	-----------------
 	-- Set up Cmdr --
 	-----------------
-	Cmdr = require(ReplicatedStorage.Packages.Cmdr)
+	Cmdr = require(script.Parent.Parent.Parent.Parent.Cmdr)
 	Cmdr:RegisterDefaultCommands()
 	Cmdr:RegisterCommandsIn(script.Commands)
 

--- a/src/Server/Services/EngineDebugService/init.lua
+++ b/src/Server/Services/EngineDebugService/init.lua
@@ -12,7 +12,6 @@ EngineEngineDebugService.Client.Server=EngineEngineDebugService
 -- Roblox Services --
 ---------------------
 local RunService=game:GetService("RunService")
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 --------------
 -- REQUIRES --

--- a/src/Shared/Settings/ClientPaths.lua
+++ b/src/Shared/Settings/ClientPaths.lua
@@ -12,7 +12,7 @@ local ReplicatedStorage=game:GetService("ReplicatedStorage")
 return {
 	ModulePaths = {
 		Shared = {
-			require(ReplicatedStorage.Packages["Roblox-LibModules"]),
+			require(script.Parent.Parent.Parent.Parent["Roblox-LibModules"]),
 		}
 	},
 

--- a/src/Shared/Settings/ClientPaths.lua
+++ b/src/Shared/Settings/ClientPaths.lua
@@ -7,7 +7,6 @@
 ---------------------
 -- Roblox Services --
 ---------------------
-local ReplicatedStorage=game:GetService("ReplicatedStorage")
 
 return {
 	ModulePaths = {


### PR DESCRIPTION
This PR fixes an issue where some parts of the framework were referencing its dependencies via an absolute path. These references now use relative paths to ensure compatibility in any project.